### PR TITLE
[ BB2-936 ] Adding support for using the refresh token

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -70,6 +70,7 @@
     "jet-logger": "^1.0.4",
     "jsonfile": "^6.1.0",
     "module-alias": "^2.2.2",
+    "moment": "^2.29.1",
     "morgan": "^1.10.0"
   },
   "devDependencies": {

--- a/server/src/entities/AuthorizationToken.ts
+++ b/server/src/entities/AuthorizationToken.ts
@@ -1,3 +1,5 @@
+import moment from "moment";
+
 export interface IAuthorizationToken {
     access_token: string,
     expires_in: number,
@@ -5,7 +7,7 @@ export interface IAuthorizationToken {
     scope: [string],
     refresh_token: string,
     patient: string,
-    expires_at: number
+    expires_at?: number
 }
 
 export default class AuthorizationToken implements IAuthorizationToken {
@@ -22,7 +24,7 @@ export default class AuthorizationToken implements IAuthorizationToken {
     constructor(authToken: IAuthorizationToken) {
         this.access_token = authToken.access_token;
         this.expires_in = authToken.expires_in;
-        this.expires_at = authToken.expires_at;
+        this.expires_at = authToken.expires_at ? authToken.expires_at : moment().add(this.expires_in).valueOf();
         this.patient = authToken.patient;
         this.refresh_token = authToken.refresh_token;
         this.scope = authToken.scope;

--- a/server/src/routes/Authorize.ts
+++ b/server/src/routes/Authorize.ts
@@ -19,7 +19,7 @@ export async function authorizationCallback(req: Request, res: Response) {
         }
 
         // this gets the token from Medicare.gov once the 'user' authenticates their Medicare.gov account
-        const response = await getAccessToken(req.query.code?.toString(), req.query.state?.toString());        
+        const response = await getAccessToken(req.query.code?.toString(), req.query.state?.toString());
         const authToken = new AuthorizationToken(response.data);
 
         /* DEVELOPER NOTES:

--- a/server/yarn.lock
+++ b/server/yarn.lock
@@ -1681,6 +1681,11 @@ module-alias@^2.2.2:
   resolved "https://registry.yarnpkg.com/module-alias/-/module-alias-2.2.2.tgz#151cdcecc24e25739ff0aa6e51e1c5716974c0e0"
   integrity sha512-A/78XjoX2EmNvppVWEhM2oGk3x4lLxnkEA4jTbaK97QKSDjkIoOsKQlfylt/d3kKKi596Qy3NP5XrXJ6fZIC9Q==
 
+moment@^2.29.1:
+  version "2.29.1"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.1.tgz#b2be769fa31940be9eeea6469c075e35006fa3d3"
+  integrity sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==
+
 morgan@^1.10.0:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/morgan/-/morgan-1.10.0.tgz#091778abc1fc47cd3509824653dae1faab6b17d7"


### PR DESCRIPTION
Adds in the use of the refresh token. Checks to see when the access token has expired, and then prior to gathering data it calls the token endpoint with the refresh token to generate a new access token (and refresh token as well).

Currently it is just implemented for EOB since that is the only data we are using.

Will go ahead and move this to the functions that @JFU-GIT created in his PR once that gets merged in.

Also trying to decide if we should add this to the error handler as well (if they get an access denied response, should they try refreshing the token?)