### PR TITLE
BB2-4845: Update gnutls

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -7,6 +7,9 @@ WORKDIR /server
 
 COPY . . 
 
+RUN apt-get update \
+    && apt-get install -y libgnutls30=3.7.9-2+deb12u7
+
 # In case machine is Mac M1 chip
 RUN node --version
 RUN yarn install


### PR DESCRIPTION
**JIRA Ticket:**
[BB2-4845](https://jira.cms.gov/browse/BB2-4845)


### What Does This PR Do?

Updates the server Dockerfile to have libgnutls30:arm64 equal to 3.7.9-2+deb12u7

### What Should Reviewers Watch For?

If you're reviewing this PR, please check for these things in particular:

### Validation

- Pull down the branch and cd into the server directory
  - Run docker build -t dockerfile-root .
  - Exec into running container: docker run -it docker.io/library/dockerfile-root:latest /bin/bash
  - Run dpkg -l | grep gnutls
  - Confirm you see  libgnutls30:arm64 equal to 3.7.9-2+deb12u7
- Build the project and successfully go through an auth flow at localhost:3000
