### PR TITLE
upgrading libssh2

### DIFF
--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -12,7 +12,7 @@ WORKDIR /client
 COPY . .
 
 RUN apt-get update && \
-    apt-get install -y libgnutls30 libcap2
+    apt-get install -y libgnutls30 libcap2 libssh2-1
 
 # In case machine is Mac M1 chip
 RUN node --version

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -8,7 +8,7 @@ WORKDIR /server
 COPY . . 
 
 RUN apt-get update && \
-    apt-get install -y libgnutls30 libcap2
+    apt-get install -y libgnutls30 libcap2 libssh2-1
 
 # In case machine is Mac M1 chip
 RUN node --version


### PR DESCRIPTION
JIRA Ticket:
[BB2-4954](https://jira.cms.gov/browse/BB2-4954)

What Does This PR Do?
Upgrades libssh2 to be a later version. Since apt-get uses the latest on whatever image it is running on, the 3.11 image had to be changed to slim-trixie to get a later version with less disruption

What Should Reviewers Watch For?
Any breaking portions of the site

Validation
Run locally with docker compose up from the base repository
